### PR TITLE
Fix indentation of .travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,7 @@ rvm:
   - 2.1
   - 2.0
   - 1.9.3
-env:
-  matrix:
-    fast_finish: true
-    allow_failures:
-      - rvm: ruby-head
+matrix:
+  fast_finish: true
+  allow_failures:
+    - rvm: ruby-head

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,13 @@ language: ruby
 sudo: false
 cache: bundler
 rvm:
-- ruby-head
-- 2.2
-- 2.1
-- 2.0
-- 1.9.3
+  - ruby-head
+  - 2.2
+  - 2.1
+  - 2.0
+  - 1.9.3
 env:
-matrix:
-fast_finish: true
-allow_failures:
-- rvm: ruby-head
-on_success: change # options: [always|never|change] default: always
-on_failure: always # options: [always|never|change] default: always
-on_start: false # default: false
+  matrix:
+    fast_finish: true
+    allow_failures:
+      - rvm: ruby-head


### PR DESCRIPTION
After this commit, `ruby-head` is allowed to fail on Travis.
